### PR TITLE
Remove dependency on SampleParserDefinition

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -52,3 +52,4 @@ CONTRIBUTORS:
 
 YYYY/MM/DD, github id, Full name, email
 2015/11/09, parrt, Terence Parr, parrt@antlr.org
+2016/02/23, yegorpetrov, Yegor Petrov, petrov.yegor@gmail.com

--- a/src/org/antlr/jetbrains/adaptor/psi/IdentifierDefSubtree.java
+++ b/src/org/antlr/jetbrains/adaptor/psi/IdentifierDefSubtree.java
@@ -6,7 +6,6 @@ import com.intellij.psi.PsiNameIdentifierOwner;
 import com.intellij.psi.PsiNamedElement;
 import com.intellij.util.IncorrectOperationException;
 import org.antlr.jetbrains.adaptor.psi.ANTLRPsiNode;
-import org.antlr.jetbrains.sample.SampleParserDefinition;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -22,8 +21,15 @@ import org.jetbrains.annotations.Nullable;
  *  for more details.
  */
 public abstract class IdentifierDefSubtree extends ANTLRPsiNode implements PsiNameIdentifierOwner {
-	public IdentifierDefSubtree(@NotNull ASTNode node) {
+	/**
+	 * Gets the {@link IElementType} of the ID/Identifier rule for
+	 * use in {@link #getNameIdentifier}
+	 */
+	private final IElementType idElementType;
+
+	public IdentifierDefSubtree(@NotNull ASTNode node, @NotNull IElementType idElementType) {
 		super(node);
+		this.idElementType = idElementType;
 	}
 
 	@Override
@@ -35,7 +41,7 @@ public abstract class IdentifierDefSubtree extends ANTLRPsiNode implements PsiNa
 	@Nullable
 	@Override
 	public PsiElement getNameIdentifier() {
-		ASTNode idNode = getNode().findChildByType(SampleParserDefinition.ID);
+		ASTNode idNode = getNode().findChildByType(idElementType);
 		if (idNode != null) {
 			return idNode.getPsi();
 		}


### PR DESCRIPTION
Pass the actual IElementType from within the dependent project. Sorry about three commits instead of one.